### PR TITLE
quadratic to cubic conversion, and Qu2Cu pens

### DIFF
--- a/Lib/cu2qu/__init__.py
+++ b/Lib/cu2qu/__init__.py
@@ -277,6 +277,8 @@ def merge_curves(p):
     segments sharing the middle point.
     Inspired by an answer on math.stackexchange.com: http://goo.gl/hFFQl0
     """
+    if isinstance(p[0], tuple):
+        p = [complex(x, y) for (x, y) in p]
     p1, p2, p3, p4, p5, p6, p7 = p
     k = abs(p5 - p4)/abs(p4 - p3)
     off1 = (1+k)*p2 - k*p1

--- a/Lib/cu2qu/__init__.py
+++ b/Lib/cu2qu/__init__.py
@@ -17,7 +17,7 @@ from __future__ import print_function, division, absolute_import
 
 __version__ = "1.4.1.dev0"
 
-__all__ = ['curve_to_quadratic', 'curves_to_quadratic']
+__all__ = ['curve_to_quadratic', 'curves_to_quadratic', 'quadratic_to_curve']
 
 MAX_N = 100
 
@@ -265,3 +265,47 @@ def curves_to_quadratic(curves, max_errors):
 
     raise ApproxNotFoundError(curves)
 
+
+def elevate_quadratic(p):
+    """Given a quadratic bezier curve, return its degree-elevated cubic."""
+    return [p[0], lerp_pt(p[0], p[1], 2/3), lerp_pt(p[2], p[1], 2/3), p[2]]
+
+
+def merge_curves(p):
+    """ Return the initial cubic bezier curve subdivided in two segments.
+    Input must be a sequence of 7 points, i.e. two consecutive cubic curve
+    segments sharing the middle point.
+    Inspired by an answer on math.stackexchange.com: http://goo.gl/hFFQl0
+    """
+    (x1, y1), (x2, y2), (x3, y3), (x4, y4), (x5, y5), (x6, y6), (x7, y7) = p
+    k = dist((x5, y5), (x4, y4))/dist((x4, y4), (x3, y3))
+    off1 = (1+k)*x2 - k*x1, (1+k)*y2 - k*y1
+    off2 = ((1+k)*x6 - x7)/k, ((1+k)*y6 - y7)/k
+    return [(x1, y1), off1, off2, (x7, y7)]
+
+
+def quadratic_to_curve(p):
+    """ Convert a quadratic spline to a _single_ cubic bezier curve.
+    NOTE: The accuracy of the conversion depends on whether the quadratic
+    spline was in turn generated as an approximation of a cubic bezier, as
+    well as on the approximation error.
+    """
+    # TODO(anthrotype): return a sequence of cubic curves if the distance
+    # from the input quadratic spline exceeds some user-defined tolerance?
+    assert len(p) >= 3, "quadratic spline requires at least 3 points"
+    q = list(p)
+    count = 0
+    num_offcurves = len(p) - 2
+    # if spline has more than one offcurve, insert interpolated oncurves
+    for i in range(1, num_offcurves):
+        off1 = p[i]
+        off2 = p[i+1]
+        on = lerp_pt(off1, off2, 0.5)
+        q.insert(i+1+count, on)
+        count += 1
+    # elevate quadratic segments to cubic, and join them together
+    curve = elevate_quadratic(q[:3])
+    for i in range(4, len(q), 2):
+        cubic_segment = elevate_quadratic([q[i-2], q[i-1], q[i]])
+        curve = merge_curves(curve + cubic_segment[1:])
+    return curve

--- a/Lib/cu2qu/pens.py
+++ b/Lib/cu2qu/pens.py
@@ -234,8 +234,15 @@ class BaseFilterPointPen(BasePointToSegmentPen):
                 else:
                     assert len(points) >= 3, (
                         "illegal curve segment point count: %d" % len(points))
-                for (pt, smooth, name, kwargs) in points[:-1]:
-                    pen.addPoint(pt, None, smooth, name, **kwargs)
+                offcurves = points[:-1]
+                if offcurves:
+                    if i == 0:
+                        # any off-curve points preceding the first on-curve
+                        # will be appended at the end of the contour
+                        last_offcurves = offcurves
+                    else:
+                        for (pt, smooth, name, kwargs) in offcurves:
+                            pen.addPoint(pt, None, smooth, name, **kwargs)
                 pt, smooth, name, kwargs = points[-1]
                 pen.addPoint(pt, segment_type, smooth, name, **kwargs)
             else:

--- a/tests/pens_test.py
+++ b/tests/pens_test.py
@@ -227,41 +227,6 @@ class TestCu2QuPen(unittest.TestCase, _TestPenMixin):
             "pen.addComponent('a', (1, 2, 3, 4, 5.0, 6.0))",
         ])
 
-    def test_ignore_single_points(self):
-        pen = DummyPen()
-        try:
-            logging.captureWarnings(True)
-            with CapturingLogHandler("py.warnings", level="WARNING") as log:
-                quadpen = Cu2QuPen(pen, MAX_ERR, ignore_single_points=True)
-        finally:
-            logging.captureWarnings(False)
-        quadpen.moveTo((0, 0))
-        quadpen.endPath()
-        quadpen.moveTo((1, 1))
-        quadpen.closePath()
-
-        self.assertGreaterEqual(len(log.records), 1)
-        self.assertIn("ignore_single_points is deprecated",
-                      log.records[0].args[0])
-
-        # single-point contours were ignored, so the pen commands are empty
-        self.assertFalse(pen.commands)
-
-        # redraw without ignoring single points
-        quadpen.ignore_single_points = False
-        quadpen.moveTo((0, 0))
-        quadpen.endPath()
-        quadpen.moveTo((1, 1))
-        quadpen.closePath()
-
-        self.assertTrue(pen.commands)
-        self.assertEqual(str(pen).splitlines(), [
-            "pen.moveTo((0, 0))",
-            "pen.endPath()",
-            "pen.moveTo((1, 1))",
-            "pen.closePath()"
-        ])
-
 
 class TestCu2QuPointPen(unittest.TestCase, _TestPenMixin):
 

--- a/tests/pens_test.py
+++ b/tests/pens_test.py
@@ -193,29 +193,6 @@ class TestCu2QuPointPen(unittest.TestCase, _TestPenMixin):
         self.pen_getter_name = 'getPointPen'
         self.draw_method_name = 'drawPoints'
 
-    def test_super_bezier_curve(self):
-        pen = DummyPointPen()
-        quadpen = Cu2QuPointPen(pen, MAX_ERR)
-        quadpen.beginPath()
-        quadpen.addPoint((0, 0), segmentType="move")
-        quadpen.addPoint((1, 1))
-        quadpen.addPoint((2, 2))
-        quadpen.addPoint((3, 3))
-        quadpen.addPoint(
-            (4, 4), segmentType="curve", smooth=False, name="up", selected=1)
-        quadpen.endPath()
-
-        self.assertEqual(str(pen).splitlines(), """\
-pen.beginPath()
-pen.addPoint((0, 0), name=None, segmentType='move', smooth=False)
-pen.addPoint((0.75, 0.75), name=None, segmentType=None, smooth=False)
-pen.addPoint((1.625, 1.625), name=None, segmentType=None, smooth=False)
-pen.addPoint((2, 2), name=None, segmentType='qcurve', smooth=True)
-pen.addPoint((2.375, 2.375), name=None, segmentType=None, smooth=False)
-pen.addPoint((3.25, 3.25), name=None, segmentType=None, smooth=False)
-pen.addPoint((4, 4), name='up', segmentType='qcurve', selected=1, smooth=False)
-pen.endPath()""".splitlines())
-
     def test__flushContour_restore_starting_point(self):
         pen = DummyPointPen()
         quadpen = Cu2QuPointPen(pen, MAX_ERR)

--- a/tests/pens_test.py
+++ b/tests/pens_test.py
@@ -145,14 +145,12 @@ class TestCu2QuPen(unittest.TestCase, _TestPenMixin):
         pen = DummyPen()
         quadpen = Cu2QuPen(pen, MAX_ERR)
         quadpen.moveTo((0, 0))
-        quadpen.qCurveTo((1, 1))
 
-        self.assertEqual(str(pen).splitlines(), [
-            "pen.moveTo((0, 0))",
-            "pen.lineTo((1, 1))",
-        ])
+        with self.assertRaisesRegex(
+                AssertionError, "illegal qcurve segment point count: 1"):
+            quadpen.qCurveTo((1, 1))
 
-    def test_qCurveTo_more_than_1_point(self):
+    def test_qCurveTo(self):
         pen = DummyPen()
         quadpen = Cu2QuPen(pen, MAX_ERR)
         quadpen.moveTo((0, 0))
@@ -163,37 +161,7 @@ class TestCu2QuPen(unittest.TestCase, _TestPenMixin):
             "pen.qCurveTo((1, 1), (2, 2))",
         ])
 
-    def test_curveTo_no_points(self):
-        quadpen = Cu2QuPen(DummyPen(), MAX_ERR)
-        quadpen.moveTo((0, 0))
-
-        with self.assertRaisesRegex(
-                AssertionError, "illegal curve segment point count: 0"):
-            quadpen.curveTo()
-
-    def test_curveTo_1_point(self):
-        pen = DummyPen()
-        quadpen = Cu2QuPen(pen, MAX_ERR)
-        quadpen.moveTo((0, 0))
-        quadpen.curveTo((1, 1))
-
-        self.assertEqual(str(pen).splitlines(), [
-            "pen.moveTo((0, 0))",
-            "pen.lineTo((1, 1))",
-        ])
-
-    def test_curveTo_2_points(self):
-        pen = DummyPen()
-        quadpen = Cu2QuPen(pen, MAX_ERR)
-        quadpen.moveTo((0, 0))
-        quadpen.curveTo((1, 1), (2, 2))
-
-        self.assertEqual(str(pen).splitlines(), [
-            "pen.moveTo((0, 0))",
-            "pen.qCurveTo((1, 1), (2, 2))",
-        ])
-
-    def test_curveTo_3_points(self):
+    def test_curveTo(self):
         pen = DummyPen()
         quadpen = Cu2QuPen(pen, MAX_ERR)
         quadpen.moveTo((0, 0))
@@ -202,19 +170,6 @@ class TestCu2QuPen(unittest.TestCase, _TestPenMixin):
         self.assertEqual(str(pen).splitlines(), [
             "pen.moveTo((0, 0))",
             "pen.qCurveTo((0.75, 0.75), (2.25, 2.25), (3, 3))",
-        ])
-
-    def test_curveTo_more_than_3_points(self):
-        # a 'SuperBezier' as described in fontTools.basePen.AbstractPen
-        pen = DummyPen()
-        quadpen = Cu2QuPen(pen, MAX_ERR)
-        quadpen.moveTo((0, 0))
-        quadpen.curveTo((1, 1), (2, 2), (3, 3), (4, 4))
-
-        self.assertEqual(str(pen).splitlines(), [
-            "pen.moveTo((0, 0))",
-            "pen.qCurveTo((0.75, 0.75), (1.625, 1.625), (2, 2))",
-            "pen.qCurveTo((2.375, 2.375), (3.25, 3.25), (4, 4))",
         ])
 
     def test_addComponent(self):


### PR DESCRIPTION
This PR implements a way to convert quadratic b-splines to cubic beziers, provided the former originated from a cubic-to-quadratic conversion.

I called the main function `quadratic_to_curve`, since we already have a `curve_to_quadratic`, although `quadratic_to_cubic` would have been clearer.

For some of you all this may seem obvious, but I was quite excited when I discovered how easy is to reverse the De Casteljeau algorithm, and thus merge back two curve segments into the original, un-splitted curve.. :)

The inspiration came from [this math.stackexchange.com answer](http://math.stackexchange.com/questions/877725/retrieve-the-initial-cubic-b%C3%A9zier-curve-subdivided-in-two-b%C3%A9zier-curves/879213#879213).

I also added two filter pens, Qu2CuPen and Qu2CuPointPen, that can be used with a glyph's `draw` or `drawPoints` method to convert "qcurve" segments to "curve".

I haven't had the chance to write proper unit tests, but I plan to add those soon.

Any comments and patches are welcome, thanks!
