### PR TITLE
cu2qu/ufo: must use PointToSegmentPen with outputImpliedClosingLine=True

### DIFF
--- a/tests/ufo_test.py
+++ b/tests/ufo_test.py
@@ -244,3 +244,42 @@ class GlyphsToQuadraticTest(object):
         pen.closePath()
         assert glyph_to_quadratic(glyph)
         assert len(glyph.components) == 1
+
+    def test_overlapping_start_end_points(self):
+        # https://github.com/googlefonts/fontmake/issues/572
+        glyph1 = Glyph()
+        pen = glyph1.getPointPen()
+        pen.beginPath()
+        pen.addPoint((0, 651), segmentType="line")
+        pen.addPoint((0, 101), segmentType="line")
+        pen.addPoint((0, 101), segmentType="line")
+        pen.addPoint((0, 651), segmentType="line")
+        pen.endPath()
+
+        glyph2 = Glyph()
+        pen = glyph2.getPointPen()
+        pen.beginPath()
+        pen.addPoint((1, 651), segmentType="line")
+        pen.addPoint((2, 101), segmentType="line")
+        pen.addPoint((3, 101), segmentType="line")
+        pen.addPoint((4, 651), segmentType="line")
+        pen.endPath()
+
+        glyphs = [glyph1, glyph2]
+
+        assert glyphs_to_quadratic(glyphs, reverse_direction=True)
+
+        assert [[(p.x, p.y) for p in glyph[0]] for glyph in glyphs] == [
+            [
+                (0, 651),
+                (0, 651),
+                (0, 101),
+                (0, 101),
+            ],
+            [
+                (1, 651),
+                (4, 651),
+                (3, 101),
+                (2, 101)
+            ],
+        ]


### PR DESCRIPTION
When collecting a glyph's segments, we can't simply call the glyphs' draw method with the GetSegmentsPen, but we must initialize the PointToSegmentPen explicitly with `outputImpliedClosingLine=True`.
By default PointToSegmentPen does not outputImpliedClosingLine -- unless last and first point on closed contour are duplicated.
Because we are converting multiple glyphs at the same time, we want to make sure the `_get_segments` function returns the same number of segments, whether or not the last and first point overlap.

Fixes https://github.com/googlefonts/fontmake/issues/572

Also see: https://github.com/fonttools/fonttools/pull/1720