### PR TITLE
Build python 3.11 wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu-20.04", "windows-2019", "macos-11" ]
+        os: [ "ubuntu-latest", "windows-latest", "macos-latest" ]
     env:
       CIBW_ARCHS: auto64
       # macOS: Explicitly list ARM variants here for cross-compilation.
@@ -41,7 +41,7 @@ jobs:
 
   build-pure:
     name: Build sdist and pure wheel
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v2
         with:
@@ -50,7 +50,7 @@ jobs:
       # Use PyPy just so we can test the package on it.
       - uses: actions/setup-python@v2
         with:
-          python-version: 'pypy-3.7'
+          python-version: 'pypy-3.9'
       - name: Install packaging tooling
         run: python -m pip install -U pip setuptools wheel
       - name: Build sdist and pure wheel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           python-version: "3.x"
       - name: Install cibuildwheel
-        run: python -m pip install -U pip cibuildwheel==2.0.1
+        run: python -m pip install -U pip cibuildwheel
       - name: Build wheels
         run: python -m cibuildwheel --output-dir dist
       - uses: actions/upload-artifact@v2

--- a/tests/pens_test.py
+++ b/tests/pens_test.py
@@ -1,4 +1,5 @@
 from __future__ import print_function, division, absolute_import
+import sys
 import unittest
 
 from cu2qu.pens import Cu2QuPen, Cu2QuPointPen
@@ -244,8 +245,12 @@ class TestCu2QuPen(unittest.TestCase, _TestPenMixin):
         quadpen.closePath()
 
         self.assertGreaterEqual(len(log.records), 1)
-        self.assertIn("ignore_single_points is deprecated",
-                      log.records[0].args[0])
+        if sys.version_info < (3, 11):
+            self.assertIn("ignore_single_points is deprecated",
+                          log.records[0].args[0])
+        else:
+            self.assertIn("ignore_single_points is deprecated",
+                          log.records[0].msg)
 
         # single-point contours were ignored, so the pen commands are empty
         self.assertFalse(pen.commands)


### PR DESCRIPTION
by simply re-running the latest cibuildwheel and hope for the best